### PR TITLE
MsSqlServerManagementStudio2014Express: Fix problems

### DIFF
--- a/MsSqlServerManagementStudio2014Express/MsSqlServerManagementStudio2014Express.nuspec
+++ b/MsSqlServerManagementStudio2014Express/MsSqlServerManagementStudio2014Express.nuspec
@@ -18,6 +18,9 @@
         <copyright />
         <language>en-US</language>
         <tags>sql mssql server 2014 express ssms management studio</tags>
+        <dependencies>
+            <dependency id="dotnet3.5" />
+        </dependencies>
     </metadata>
   <files>
     <file src="tools\**\*" target="tools" />

--- a/MsSqlServerManagementStudio2014Express/tools/ChocolateyInstall.ps1
+++ b/MsSqlServerManagementStudio2014Express/tools/ChocolateyInstall.ps1
@@ -1,5 +1,5 @@
 $packageName = "MsSqlServerManagementStudio2014Express"
-$chocolateyTempDir = Join-Path $env:TEMP "chocolatey"
+$chocolateyTempDir = Join-Path (Get-Item $env:TEMP).FullName "chocolatey"
 $tempDir = Join-Path $chocolateyTempDir $packageName
 $fileFullPath = "$tempDir\SQLManagementStudio.exe"
 $extractPath = "$tempDir\SQLManagementStudio"


### PR DESCRIPTION
This PR adds the missing .NET 3.5 dependency and it fixes a problem with the usage of the `$env:TEMP` variable.
On my machine, the install failed with a specific error. Research brought me to a [question in the MSDN forums](https://social.msdn.microsoft.com/Forums/sqlserver/en-US/21bdfe6d-9340-47e6-99b2-0305c9d37bf9/sql-server-enterprise-core-2012?forum=sqlsetupandupgrade&prof=required).
The first accepted answer proposes disabling 8.3 for the filesystem and indeed, in the chocolatey error message I could see that the path of the setup.exe was a 8.3 path.
I encountered similar errors before when the 8.3 path was used.
I fixed it by using the full path instead of the 8.3 version - now the install works on my machine. I also tested it on a machine where the username had a space in it. Also worked.
