### PR TITLE
Fix a few issues in KB2919442 and KB2919355

### DIFF
--- a/KB2919355/KB2919355.nuspec
+++ b/KB2919355/KB2919355.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>KB2919355</id>
-        <version>1.0.20160719</version>
+        <version>1.0.20160915</version>
         <title>Windows RT 8.1, Windows 8.1, and Windows Server 2012 R2 update: April 2014 (KB2919355)</title>
         <authors>Microsoft</authors>
         <owners>Manuel Riezebosch</owners>
@@ -20,10 +20,13 @@ On systems other than Windows 8.1 or Windows Server 2012 R2, this package instal
 This update is required to install Visual Studio 2015 on Windows 8.1 or Windows Server 2012 R2.
         </description>
         <summary>This update is a cumulative update that includes the security updates and the non-security updates for Windows RT 8.1, Windows 8.1, and Windows Server 2012 R2 that were released before March 2014.</summary>
-        <releaseNotes></releaseNotes>
+        <releaseNotes>
+1.0.20160915:
+- fixed installation on PowerShell 2.0
+        </releaseNotes>
         <tags>Microsoft Visual Studio 2015 Windows Update KB2919355</tags>
         <dependencies>
-          <dependency id="KB2919442" version="1.0.20160719" />
+          <dependency id="KB2919442" version="1.0.20160915" />
         </dependencies>
     </metadata>
   <files>

--- a/KB2919355/Tools/ChocolateyInstall.ps1
+++ b/KB2919355/Tools/ChocolateyInstall.ps1
@@ -28,4 +28,4 @@ if ($os.ProductType -eq '1') {
 	$checksum64 = 'B0C9ADA530F5EE90BB962AFA9ED26218C582362315E13B1BA97E59767CB7825D'
 }
 
-Install-ChocolateyPackage $packageName 'msu' $silentArgs $url $url64 -checksum $checksum -checksum64 $checksum64 -checksumType 'sha256' -validExitCodes @(0, 3010)
+Install-ChocolateyPackage $packageName 'msu' $silentArgs $url $url64 -checksum $checksum -checksum64 $checksum64 -checksumType 'sha256' -validExitCodes @(0, 3010, 0x80240017)

--- a/KB2919355/Tools/ChocolateyInstall.ps1
+++ b/KB2919355/Tools/ChocolateyInstall.ps1
@@ -2,8 +2,7 @@ $kb = "KB2919355"
 $packageName = "KB2919355"
 $silentArgs = "/quiet /norestart /log:`"$env:TEMP\$kb.Install.evt`""
 
-# Get-CimInstance only available on Powershell v3+ which is shipped since Windows 8 & Windows Server 2012
-$os = Get-CimInstance Win32_OperatingSystem -ea SilentlyContinue 
+$os = Get-WmiObject -Class Win32_OperatingSystem
 $version = [Version]$os.Version
 
 if ($version -eq $null -or $version -lt [Version]'6.3' -or $version -ge [Version]'6.4') {

--- a/KB2919442/KB2919442.nuspec
+++ b/KB2919442/KB2919442.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>KB2919442</id>
-        <version>1.0.20160719</version>
+        <version>1.0.20160915</version>
         <title>March 2014 servicing stack update for Windows 8.1 and Windows Server 2012 R2 (KB2919442)</title>
         <authors>Microsoft</authors>
         <owners>Manuel Riezebosch</owners>
@@ -18,7 +18,11 @@ On systems other than Windows 8.1 or Windows Server 2012 R2, this package instal
 This update is required to install Visual Studio 2015 on Windows 8.1 or Windows Server 2012 R2.
         </description>
         <summary>The update fixes some issues in the servicing stack of Windows 8.1 and Windows Server 2012 R2.</summary>
-        <releaseNotes></releaseNotes>
+        <releaseNotes>
+1.0.20160915:
+- fixed installation on PowerShell 2.0
+- fixed installation on machines which already have a superseding hotfix installed
+        </releaseNotes>
         <tags>Microsoft Visual Studio 2015 Windows Update 2919442</tags>
         <dependencies>
         </dependencies>

--- a/KB2919442/Tools/ChocolateyInstall.ps1
+++ b/KB2919442/Tools/ChocolateyInstall.ps1
@@ -28,4 +28,4 @@ if ($os.ProductType -eq '1') {
 	$checksum64 = 'C10787E669B484674584A990E069295E8B81B5366F98508010A3AE181B729482'
 }
 
-Install-ChocolateyPackage $packageName 'msu' $silentArgs $url $url64 -checksum $checksum -checksum64 $checksum64 -checksumType 'sha256' -validExitCodes @(0, 3010)
+Install-ChocolateyPackage $packageName 'msu' $silentArgs $url $url64 -checksum $checksum -checksum64 $checksum64 -checksumType 'sha256' -validExitCodes @(0, 3010, 0x80240017)

--- a/KB2919442/Tools/ChocolateyInstall.ps1
+++ b/KB2919442/Tools/ChocolateyInstall.ps1
@@ -2,8 +2,7 @@ $kb = "KB2919442"
 $packageName = "KB2919442"
 $silentArgs = "/quiet /norestart /log:`"$env:TEMP\$kb.Install.evt`""
 
-# Get-CimInstance only available on Powershell v3+ which is shipped since Windows 8 & Windows Server 2012
-$os = Get-CimInstance Win32_OperatingSystem -ea SilentlyContinue 
+$os = Get-WmiObject -Class Win32_OperatingSystem
 $version = [Version]$os.Version
 
 if ($version -eq $null -or $version -lt [Version]'6.3' -or $version -ge [Version]'6.4') {


### PR DESCRIPTION
1) support PowerShell 2.0
2) handle cases when Get-HotFix does not return the given KB as installed because it has been superseded by a newer KB and wusa.exe returns WU_E_NOT_APPLICABLE
