### PR TITLE
Enable custom options during install.

### DIFF
--- a/sql-server-express/sql-server-express.nuspec
+++ b/sql-server-express/sql-server-express.nuspec
@@ -2,7 +2,6 @@
 <!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
-    <!-- Read this before publishing packages to chocolatey.org: https://github.com/chocolatey/chocolatey/wiki/CreatePackages -->
     <id>sql-server-express</id>
     <title>Microsoft SQL Server 2016 Express (Install)</title>
     <version>13.0.1601.5</version>
@@ -10,25 +9,29 @@
     <owners>riezebosch</owners>
     <summary>Installs SQL Server 2016 Express database engine.</summary>
     <description>
-      Entry-level, free database that is ideal for deploying small databases in production environments. Build desktop and small server, data-driven applications up to 10 GB of disk size.
+Entry-level, free database that is ideal for deploying small databases in production environments. Build desktop and small server, data-driven applications up to 10 GB of disk size.
+
+Optional installation commands:
+The sql server installer supports dozen of options for customizing the install. This package installs using options that match the default settings from the UI installer, 
+but it supports adding to or modifying the feature list. Only a couple of examples are shown here, but there are dozens of install options avaialable,
+please refer to the install reference for more: https://msdn.microsoft.com/en-us/library/ms144259.aspx
+
+Note that the params are seperated by whitespace and do not include a leading slash '/' 
+
+`choco install sql-server-express -params "instanceName=*name* instanceId=*id*"` to specify a custom instanceName and/or Id.
+
+`choco install sql-server-express -params "updateEnable=TRUE"` to get updates during install.
+
+`choco install sql-server-express -params "securityMode=SQL"` to enable SqlServer authentication.
     </description>
     <projectUrl>https://www.microsoft.com/en-us/server-cloud/products/sql-server-editions/sql-server-express.aspx</projectUrl>
     <packageSourceUrl>https://github.com/riezebosch/BoxstarterPackages</packageSourceUrl>
-    <!--<projectSourceUrl></projectSourceUrl>
-    <docsUrl></docsUrl>
-    <mailingListUrl></mailingListUrl>
-    <bugTrackerUrl></bugTrackerUrl>-->
     <tags>sql server express admin 2016 express</tags>
     <copyright>2016</copyright>
     <licenseUrl>http://download.microsoft.com/download/F/D/5/FD5E5C28-6973-4273-8737-D69AA3BEA243/SQL_Server_2016_Licensing_Datasheet_EN_US.pdf</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <iconUrl>https://cdn.rawgit.com/ferventcoder/chocolatey-packages/59ad5e2e32c52fd2a45a9735f95a81368f9e5e85/icons/microsoft-sql-server.svg</iconUrl>
-    <dependencies>
-      <dependency id="vcredist2013" version="12.0.30501.20150616" />
-      <dependency id="KB2919355" version="1.0.20160719" />
-    </dependencies>
     <releaseNotes>https://msdn.microsoft.com/en-us/library/dn876712.aspx?f=255&amp;MSPPError=-2147217396</releaseNotes>
-    <!--<provides></provides>-->
   </metadata>
   <files>
     <file src="tools\**" target="tools" />

--- a/sql-server-express/tools/chocolateyHelpers.ps1
+++ b/sql-server-express/tools/chocolateyHelpers.ps1
@@ -1,0 +1,25 @@
+function Get-ChocolateyPackageTempFolder {
+    param(
+      [string] $packageName
+    )
+    $chocTempDir = Join-Path $env:TEMP "chocolatey"
+    $tempDir = Join-Path $chocTempDir "$packageName"
+    if (![System.IO.Directory]::Exists($tempDir)) {[System.IO.Directory]::CreateDirectory($tempDir) | Out-Null}
+   
+    return $tempDir
+}
+
+function Set-ChocolateyPackageOptions {
+    param(
+        [Parameter(Mandatory=$True,Position=1)]
+        [hashtable] $options
+    )
+    $packageParameters = $env:chocolateyPackageParameters;
+
+    if ($packageParameters) {
+        $parameters = ConvertFrom-StringData -StringData $env:chocolateyPackageParameters.Replace(" ", "`n")
+        $parameters.GetEnumerator() | ForEach-Object {
+           $options[($_.Key)] = ($_.Value)
+        }
+    }
+}

--- a/sql-server-express/tools/chocolateyHelpers.ps1
+++ b/sql-server-express/tools/chocolateyHelpers.ps1
@@ -2,8 +2,7 @@ function Get-ChocolateyPackageTempFolder {
     param(
       [string] $packageName
     )
-    $chocTempDir = Join-Path $env:TEMP "chocolatey"
-    $tempDir = Join-Path $chocTempDir "$packageName"
+    $tempDir = Join-Path $Env:Temp $packageName
     if (![System.IO.Directory]::Exists($tempDir)) {[System.IO.Directory]::CreateDirectory($tempDir) | Out-Null}
    
     return $tempDir

--- a/sql-server-express/tools/chocolateyinstall.ps1
+++ b/sql-server-express/tools/chocolateyinstall.ps1
@@ -1,26 +1,49 @@
-﻿$ErrorActionPreference = 'Stop';
+﻿#These are the default UI settings
+$options = @{
+  instanceId = 'MSSQLSERVER'
+  instanceName = 'SQLExpress'
+  features = '"SQLEngine, Replication"'
+  updateEnabled = 'FALSE'
+}
 
-$packageName= 'sql-server-express'
-$url        = ''
-$url64      = 'https://download.microsoft.com/download/E/1/2/E12B3655-D817-49BA-B934-CEB9DAC0BAF3/SQLEXPR_x64_ENU.exe'
-$checksum   = '7D71A44096650E2916B921BE4EC3114EF95A8775'
-$silentArgs = "/IACCEPTSQLSERVERLICENSETERMS /Q /ACTION=install /INSTANCEID=SQLEXPRESS /INSTANCENAME=SQLEXPRESS /UPDATEENABLED=FALSE"
+$packageParameters = @{
+  packageName = 'sql-server-express';
+  url = '';
+  url64bit = 'https://download.microsoft.com/download/E/1/2/E12B3655-D817-49BA-B934-CEB9DAC0BAF3/SQLEXPR_x64_ENU.exe';
+  checksum = '';
+  checksumType = '';
+  checksum64 = '7D71A44096650E2916B921BE4EC3114EF95A8775';
+  checksumType64 = 'Sha1';
+  fileFullPath = '';
+}
 
-$tempDir = Join-Path (Get-Item $env:TEMP).FullName "$packageName"
-if ($env:packageVersion -ne $null) {$tempDir = Join-Path $tempDir "$env:packageVersion"; }
+if(!$PSScriptRoot){ $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent }
+. "$PSScriptRoot\ChocolateyHelpers.ps1"
 
-if (![System.IO.Directory]::Exists($tempDir)) { [System.IO.Directory]::CreateDirectory($tempDir) | Out-Null }
-$fileFullPath = "$tempDir\SQLEXPR.exe"
+$tempFolder = Get-ChocolateyPackageTempFolder $packageParameters['packageName']
+$packageParameters['fileFullPath'] = "$tempFolder\SQLEXPR.exe"
+$extractPath = "$tempFolder\SQLEXPR"
 
-Get-ChocolateyWebFile -PackageName $packageName -FileFullPath $fileFullPath -Url $url -Url64bit $url64 -Checksum $checksum -ChecksumType 'sha1'
+Get-ChocolateyWebFile @packageParameters
 
-Write-Host "Extracting..."
-$extractPath = "$tempDir\SQLEXPR"
-Start-Process "$fileFullPath" "/Q /x:`"$extractPath`"" -Wait
+Start-Process $packageParameters['fileFullPath'] "/Q /x:`"$extractPath`"" -Wait | Out-Null
 
-Write-Host "Installing..."
-$setupPath = "$extractPath\setup.exe"
-Install-ChocolateyInstallPackage "$packageName" "EXE" "$silentArgs" "$setupPath" -validExitCodes @(0, 3010, 1116)
+$args = New-Object System.Collections.ArrayList
+$args.Add('/IACCEPTSQLSERVERLICENSETERMS') | Out-Null
+$args.Add('/Q') | Out-Null
+$args.Add('/ACTION=Install') | Out-Null
 
-Write-Host "Removing extracted files..."
-Remove-Item -Recurse "$extractPath"
+foreach($option in $options.GetEnumerator()) {
+  $key = $option.Key.ToUpper()
+  $value = $option.Value
+  if (!$value) { continue }
+  $args.Add("/$key=$value") | Out-Null
+}
+
+$joined = $args -join ' '
+Write-Host $joined
+Install-ChocolateyInstallPackage $packageParameters['packageName'] 'EXE' $joined "$extractPath\setup.exe" -validExitCodes @(0, 3010, 1116)
+
+Export-CliXml -Path (Join-Path $PSScriptRoot 'options.xml') -InputObject $options
+
+#Dont cleanup the media. Add or removing features and instances requires it.

--- a/sql-server-express/tools/chocolateyuninstall.ps1
+++ b/sql-server-express/tools/chocolateyuninstall.ps1
@@ -1,7 +1,24 @@
-﻿$ErrorActionPreference = 'Stop';
+﻿$packageName = 'sql-server-express'
 
-$packageName= 'sql-server-express'
-$silentArgs = ""
+if(!$PSScriptRoot){ $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent }
+. "$PSScriptRoot\ChocolateyHelpers.ps1"
 
-$setupPath = (Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Microsoft SQL Server SQLServer2016').UninstallString
-Uninstall-ChocolateyPackage "$packageName" "EXE" "$silentArgs" "$setupPath" -validExitCodes @(0, 3010)
+$tempFolder = Get-ChocolateyPackageTempFolder $packageName
+$setupPath = "$tempFolder\SQLEXPR\setup.exe"
+
+$optionsFile = (Join-Path $PSScriptRoot 'options.xml')
+if (!(Test-Path $optionsFile)) {
+  throw "Install options file missing. Could not uninstall."
+}
+
+$options = Import-CliXml -Path $optionsFile
+
+$args = New-Object System.Collections.ArrayList
+$args.Add('/Q') | Out-Null
+$args.Add('/ACTION=Uninstall') | Out-Null
+$args.Add("/INSTANCENAME=$($options['instanceName'])") | Out-Null
+$args.Add("/FEATURES=$($options['features'])") | Out-Null
+
+$joined = $args -join ' '
+
+Uninstall-ChocolateyPackage $packageName 'EXE' $joined "$setupPath" -validExitCodes @(0, 3010)


### PR DESCRIPTION
This PR addresses the issues I pinged you about on chocolatey's disqus comments (http://disq.us/p/1c89h0r) on Fri.
- Removes the dependencies. Like .Net, I think there are many platform things that must be on the system before you can install this package. I don't think that adding the April 2014 KB update or the redist package are that useful and given that the KB update blocks the acceptance of this package as a whole, removing them seems like the prudent option.
- Updates the install mechanism to allow for a custom list of installer options. This is the same technique I use for the teamcity package where I have a hashtable of default/mandatory options that can be overwritten or added to by the chocolatey params the user passes into the package. The logic for the param updating is located in the chocolateyHelpers.ps1 file.
- Updates the options to match the default UI settings. The instanceId is 'MSSQLSERVER' and the instanceName is 'SQLExpress'. 
- Changes the uninstall to use the extracted setup.exe so that the install options can be used for uninstalling. Since the user has the ability to add other instances using the UI doing this allows the uninstaller to remove the chocolatey controlled instance. The Uninstall action mandates that the name and features be included in the arguments.
- Removes the cleanup of the installation media. Since this is required to uninstall, leaving it seems like a prudent option. I do think it would be better to extract to the chocolatey package lib folder, but I kept the temp folder logic for now.
- Updates the nupkg with a couple of examples of passing in custom options and adds a link to the installer options documentation.

I've hit my limit for vm testing at the moment. I'll run through a couple of more images tomorrow morning, but this should pack/install correctly.
