### PR TITLE
Update Docker 1.13.0

### DIFF
--- a/docker-for-windows/docker-for-windows.nuspec
+++ b/docker-for-windows/docker-for-windows.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>docker-for-windows</id>
-    <version>1.12.6.9655</version>
+    <version>1.13.0.9795</version>
      <packageSourceUrl>https://github.com/riezebosch/BoxstarterPackages/</packageSourceUrl>
     <owners>riezebosch</owners>
 

--- a/docker-for-windows/tools/chocolateyinstall.ps1
+++ b/docker-for-windows/tools/chocolateyinstall.ps1
@@ -1,4 +1,4 @@
-﻿$version = "1.12.6.9655"
+﻿$version = "1.13.0.9795"
 $ErrorActionPreference = 'Stop';
 
 $packageName= 'docker-for-windows'
@@ -13,7 +13,7 @@ $packageArgs = @{
 
   softwareName  = 'docker*'
 
-  checksum      = 'ff51ea25ebd8ae4e47363834330d5fa55f43453f8ca8f79872ec1422d299d984'
+  checksum      = 'e97554ccfce148121c6681744ab4606515ba9a5cbfe8e10614f5deb667ec5d4b'
   checksumType  = 'sha256'
  
   silentArgs    = "/qn /norestart /l*v `"$($env:TEMP)\$($packageName).$($env:chocolateyPackageVersion).MsiInstall.log`""


### PR DESCRIPTION
New Docker for Windows 1.13.0 has been released. 
So I've tried your update script, but I'm on a Mac, so how to run the PowerShell script that is written for Windows on a Mac? Within a Windows Container with a little help of a [Windows Docker machine](https://github.com/StefanScherer/windows-docker-machine) :-)

```
docker run -v C:$(pwd):C:/update microsoft/windowsservercore powershell -Command 'cd c:\update ; . .\Update-Version.ps1'
```

<img width="1122" alt="bildschirmfoto 2017-01-20 um 15 12 50" src="https://cloud.githubusercontent.com/assets/207759/22152406/1d7886e4-df23-11e6-9e37-c5cbbf74b8eb.png">

Signed-off-by: Stefan Scherer <scherer_stefan@icloud.com>