### PR TITLE
dotnetcore-sdk: add required dependency

### DIFF
--- a/dotnetcore-sdk/dotnetcore-sdk.nuspec
+++ b/dotnetcore-sdk/dotnetcore-sdk.nuspec
@@ -5,7 +5,7 @@
     <!-- Read this before publishing packages to chocolatey.org: https://github.com/chocolatey/chocolatey/wiki/CreatePackages -->
     <id>dotnetcore-sdk</id>
     <title>.NET Core SDK</title>
-    <version>2.0.0</version>
+    <version>2.0.0.20170905</version>
     <authors>Microsoft</authors>
     <owners>riezebosch</owners>
     <summary>The SDK includes the runtime and command line tools for creating .NET Core applications</summary>
@@ -25,6 +25,7 @@
     <iconUrl>http://cdn.rawgit.com/riezebosch/BoxstarterPackages/master/dotnetcore-sdk/icon/dotnet_logo.png</iconUrl>
     <dependencies>
       <dependency id="vcredist2015" version="14.0.24215.20160928" />
+      <dependency id="KB2533623" version="1.0.2" />
     </dependencies>
     <releaseNotes>https://github.com/dotnet/core/blob/master/release-notes/</releaseNotes>
     <!--<provides></provides>-->


### PR DESCRIPTION
As per [1], KB2533623 is required on Win7/2008. Lack of it results in:

C:\>dotnet new

Failed to load the dll from [C:\Program Files\dotnet\host\fxr\2.0.0\hostfxr.dll]
, HRESULT: 0x7CDF0
The library hostfxr.dll was found, but loading it from C:\Program Files\dotnet\h
ost\fxr\2.0.0\hostfxr.dll failed
  - Installing .NET Core prerequisites might help resolve this problem.
       http://go.microsoft.com/fwlink/?LinkID=798306&clcid=0x409

[1] https://docs.microsoft.com/en-us/dotnet/core/windows-prerequisites