### PR TITLE
Amending url in SOAPUI to be consistent

### DIFF
--- a/soapui/tools/chocolateyInstall.ps1
+++ b/soapui/tools/chocolateyInstall.ps1
@@ -1,8 +1,8 @@
 $ErrorActionPreference = 'Stop';
 $Version = "5.7.0"
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$url        = 'http://dl.eviware.com/soapuios/$Version/SoapUI-x32-$Version.exe'
-$url64      = 'http://dl.eviware.com/soapuios/$Version/SoapUI-x64-$Version.exe'
+$url        = "http://dl.eviware.com/soapuios/$Version/SoapUI-x32-$Version.exe"
+$url64      = "http://dl.eviware.com/soapuios/$Version/SoapUI-x64-$Version.exe"
 
 $packageArgs = @{
   packageName   = $env:ChocolateyPackageName

--- a/soapui/tools/chocolateyInstall.ps1
+++ b/soapui/tools/chocolateyInstall.ps1
@@ -1,7 +1,8 @@
 $ErrorActionPreference = 'Stop';
+$Version = "5.7.0"
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$url        = 'http://dl.eviware.com/soapuios/5.5.0/SoapUI-x32-5.5.0.exe'
-$url64      = 'https://s3.amazonaws.com/downloads.eviware/soapuios/5.7.0/SoapUI-x64-5.7.0.exe'
+$url        = 'http://dl.eviware.com/soapuios/$Version/SoapUI-x32-$Version.exe'
+$url64      = 'http://dl.eviware.com/soapuios/$Version/SoapUI-x64-$Version.exe'
 
 $packageArgs = @{
   packageName   = $env:ChocolateyPackageName


### PR DESCRIPTION
#58 
1. We should use the same URL for both packages
2. Moving to a variable for the version number should make bumping simpler going forward.