### PR TITLE
Remove support for 32bit installer

### DIFF
--- a/soapui/soapui.nuspec
+++ b/soapui/soapui.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>soapui</id>
-    <version>5.7.0.20220304</version>
+    <version>5.7.0.20220316</version>
     <title>SoapUI</title>
     <authors>SmartBear Software</authors>
     <owners>DanyO riezebosch</owners>

--- a/soapui/tools/chocolateyInstall.ps1
+++ b/soapui/tools/chocolateyInstall.ps1
@@ -1,25 +1,35 @@
-$ErrorActionPreference = 'Stop';
+$ErrorActionPreference = 'Stop'
 $Version = "5.7.0"
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$url        = "http://dl.eviware.com/soapuios/$Version/SoapUI-x32-$Version.exe"
 $url64      = "http://dl.eviware.com/soapuios/$Version/SoapUI-x64-$Version.exe"
+
+
 
 $packageArgs = @{
   packageName   = $env:ChocolateyPackageName
   unzipLocation = $toolsDir
   fileType      = 'EXE'
-  url           = $url
   url64bit      = $url64
-
   softwareName  = 'soapui*'
-
-  checksum      = '6f32e0f5415e759afcd88bbd19786d16263a36584d38373a54650298e53f84a0'
-  checksumType  = 'sha256'
   checksum64    = '86B6E5658886A0876D0196394F91A470E1AF7D62D3067EEB94C1F8C5293D3B18'
   checksumType64= 'sha256'
-
   silentArgs    = "-q"
   validExitCodes= @(0, 3010, 1641)
+}
+
+$regKey = Get-UninstallRegistryKey  -SoftwareName $packageArgs['softwareName'] 
+
+if ($regKey)
+{
+  $regPath = $regKey | 
+                 Select-Object -ExpandProperty PSParentPath | 
+                 Convert-Path
+
+  # Throw terminating error if 32bit version of app is installed
+  if ($regPath -eq 'HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall')
+  {
+    Write-Error ( '"{0}" is installed, the final 32 bit version available is 5.5.0' -f $regKey.DisplayName  ) 
+  }
 }
 
 Install-ChocolateyPackage @packageArgs


### PR DESCRIPTION
To fix issue #60 which occurs because the final 32bit installer available for SoapUI is version 5.5.0

1. Remove all references to the 32bit payload from chocolateyInstall.ps1
2. `choco upgrade` now fails when called to upgrade an existing 32 bit installation.

Ran tests to confirm:
-  Successful upgrade of an existing 64 bit SoapUI 5.5.0 installation.
-  Successful new 64 bit SoapUI 5.7.0 installation.

```
# Install 32bit version of the application
# choco upgrade soapui --version="5.5.0" --x86
#
# Output from failed upgrade of an existing 32 bit installation
#
> choco upgrade soapui --source="C:\Temp\choco\soapUI"
Chocolatey v0.12.1 Business
Upgrading the following packages:
soapui
By upgrading, you accept licenses for the packages.

You have soapui v5.5.0 installed. Version 5.7.0.20220316 is available based on your source(s).

soapui v5.7.0.20220316
soapui package files upgrade completed. Performing other installation steps.
ERROR: The running command stopped because the preference variable "ErrorActionPreference" or common parameter is set to Stop: "SoapUI 5.5.0" is installed, the final 32 bit version available is 5.5.0
The upgrade of soapui was NOT successful.
Error while running 'C:\ProgramData\chocolatey\lib\soapui\tools\chocolateyInstall.ps1'.
 See log for details.

Chocolatey upgraded 0/1 packages. 1 packages failed.
 See the log for details (C:\ProgramData\chocolatey\logs\chocolatey.log).

Failures
 - soapui (exited -1) - Error while running 'C:\ProgramData\chocolatey\lib\soapui\tools\chocolateyInstall.ps1'.
 See log for details.
```