### PR TITLE
Update docker-desktop to 4.36.0 using update_all.ps1

### DIFF
--- a/docker-desktop/docker-desktop.nuspec
+++ b/docker-desktop/docker-desktop.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>docker-desktop</id>
-    <version>4.34.2</version>
+    <version>4.36.0</version>
     <packageSourceUrl>https://github.com/riezebosch/BoxstarterPackages/</packageSourceUrl>
     <owners>riezebosch</owners>
     <title>Docker Desktop</title>

--- a/docker-desktop/tools/chocolateyinstall.ps1
+++ b/docker-desktop/tools/chocolateyinstall.ps1
@@ -2,8 +2,8 @@
 
 $packageName= 'docker-desktop'
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$url        = 'https://desktop.docker.com/win/main/amd64/167172/Docker%20Desktop%20Installer.exe'
-$checksum   = 'fb4f24872f6c0a75b6260ea369a3f0744a13d1e567f5e7f8fb76dffb701e31c2'
+$url        = 'https://desktop.docker.com/win/main/amd64/175267/Docker%20Desktop%20Installer.exe'
+$checksum   = '755ea81173f0621d9683808c75dff65fa4e6ef39aeefb5a7f2723b682119c20f'
 
 $packageArgs = @{
   packageName   = $packageName


### PR DESCRIPTION
Update docker-desktop to latest version using update_all.ps1. I know an earlier PR was rejected, not sure if I have to include any other files with this change, for example Update-history.md or Update-aupackages.md