### PR TITLE
Update docker-desktop to 4.38.0

### DIFF
--- a/docker-desktop/Update.ps1
+++ b/docker-desktop/Update.ps1
@@ -8,8 +8,8 @@ function global:check_url() {
 function global:au_SearchReplace {
     @{
         "tools\chocolateyInstall.ps1" = @{
-            "(^[$]url\s*=\s*)('.*')"      = "`$1'$($Latest.URL)'"           #1
-            "(^[$]checksum\s*=\s*)('.*')" = "`$1'$($Latest.Checksum32)'"      #2
+            "(^[$]url64\s*=\s*)('.*')"      = "`$1'$($Latest.url64bit)'"           #1
+            "(^[$]checksum64\s*=\s*)('.*')" = "`$1'$($Latest.checksum64)'"      #2
         }
     }
 }
@@ -23,7 +23,7 @@ function global:au_GetLatest {
 
     $url = ($enclosure | Select-Xml -XPath "@d4w:url" -Namespace @{ d4w = "http://www.docker.com/docker-for-windows"  }).Node.Value
 
-    @{ Version = $version; URL = $url }
+    @{ Version = $version; url64bit = $url }
 }
 
-update
+Update-Package -ChecksumFor 64

--- a/docker-desktop/docker-desktop.nuspec
+++ b/docker-desktop/docker-desktop.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>docker-desktop</id>
-    <version>4.37.1</version>
+    <version>4.38.0</version>
     <packageSourceUrl>https://github.com/riezebosch/BoxstarterPackages/</packageSourceUrl>
     <owners>riezebosch</owners>
     <title>Docker Desktop</title>

--- a/docker-desktop/tools/chocolateyinstall.ps1
+++ b/docker-desktop/tools/chocolateyinstall.ps1
@@ -2,8 +2,8 @@
 
 $packageName= 'docker-desktop'
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$url        = 'https://desktop.docker.com/win/main/amd64/178610/Docker%20Desktop%20Installer.exe'
-$checksum   = '331f809f1e139a868e8339af4382d2569ed7301c5341fcec834b47a30994781f'
+$url        = 'https://desktop.docker.com/win/main/amd64/181591/Docker%20Desktop%20Installer.exe'
+$checksum   = '19162592ca2998303bc75c3387057a17f07e29e4692b12c52f284e569f44bd74'
 
 $packageArgs = @{
   packageName   = $packageName

--- a/docker-desktop/tools/chocolateyinstall.ps1
+++ b/docker-desktop/tools/chocolateyinstall.ps1
@@ -1,23 +1,23 @@
 ﻿$ErrorActionPreference = 'Stop';
 
-$packageName= 'docker-desktop'
-$toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$url        = 'https://desktop.docker.com/win/main/amd64/181591/Docker%20Desktop%20Installer.exe'
-$checksum   = '19162592ca2998303bc75c3387057a17f07e29e4692b12c52f284e569f44bd74'
+$packageName = 'docker-desktop'
+$toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+$url64 = 'https://desktop.docker.com/win/main/amd64/181591/Docker%20Desktop%20Installer.exe'
+$checksum64 = '19162592ca2998303bc75c3387057a17f07e29e4692b12c52f284e569f44bd74'
 
 $packageArgs = @{
-  packageName   = $packageName
-  unzipLocation = $toolsDir
-  fileType      = 'EXE'
-  url           = $url
+  packageName    = $packageName
+  unzipLocation  = $toolsDir
+  fileType       = 'EXE'
+  url64bit       = $url64
 
-  softwareName  = 'docker*'
+  softwareName   = 'docker*'
 
-  checksum      = $checksum
-  checksumType  = 'sha256'
- 
-  silentArgs    = "install --quiet"
-  validExitCodes= @(0, 3010, 1641, 3) # 3 = InstallationUpToDate 
+  checksum64     = $checksum64
+  checksumType64 = 'sha256'
+
+  silentArgs     = "install --quiet"
+  validExitCodes = @(0, 3010, 1641, 3) # 3 = InstallationUpToDate 
 }
 
 Install-ChocolateyPackage @packageArgs


### PR DESCRIPTION
Also, PR specifies that the docker-desktop url is x64 arch only.

Docs: https://docs.docker.com/desktop/release-notes/#4380